### PR TITLE
Mismatched closing brackets

### DIFF
--- a/man/authenticate_v2_0.Rd
+++ b/man/authenticate_v2_0.Rd
@@ -8,7 +8,7 @@ authenticate_v2_x(apikey)
 }
 \arguments{
 \item{apikey.}{Your MySportsFeeds API Key}
-
+}
 \description{
 Sets the authentication credentials in R environment variables
 }


### PR DESCRIPTION
Currently, this documentation file generates an error on package installation:
```
Error : (converted from warning) /tmp/[...]/mysportsfeedsR/man/authenticate_v2_0.Rd:12: unexpected section header '\description'
```
Adding the missing bracket seems to have resolved this